### PR TITLE
Fix mga 0.9.1 hash

### DIFF
--- a/bucket/mgba.json
+++ b/bucket/mgba.json
@@ -5,12 +5,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/mgba-emu/mgba/releases/download/0.9.1/mGBA-0.9.1-win64.7z",
-            "hash": "db02f9b4fdd9d0844362e82e1ce168aa1049056054c6a21b2a6cbef94d1d9563",
+            "hash": "239224df0e061894bce5f5ea5fc2b2d2a7eaf781f15e2e32220134a451bbff28",
             "extract_dir": "mGBA-0.9.1-win64"
         },
         "32bit": {
             "url": "https://github.com/mgba-emu/mgba/releases/download/0.9.1/mGBA-0.9.1-win32.7z",
-            "hash": "c281001f5a91e82cc1d3fcf0f93dfb931faadbcc1a3ebbde14a6ed237bc8cbd7",
+            "hash": "1b17f795f41f3dce33fff80f91aa54d77a2893ab4208e607be1498e1cb4aae95",
             "extract_dir": "mGBA-0.9.1-win32"
         }
     },


### PR DESCRIPTION
Not sure why, but I'm getting hash mismatches. If it's legitimate, here's a PR to fix it. If it's on my end, please reject.

Fixes #44 