### PR TITLE
retroarch: Fix missing subdirectory for shim creation

### DIFF
--- a/bucket/retroarch.json
+++ b/bucket/retroarch.json
@@ -18,10 +18,10 @@
         "    New-Item \"$dir\\retroarch.cfg\" -Type File | Out-Null",
         "}"
     ],
-    "bin": "retroarch.exe",
+    "bin": "RetroArch-Win64/retroarch.exe",
     "shortcuts": [
         [
-            "retroarch.exe",
+            "RetroArch-Win64/retroarch.exe",
             "RetroArch"
         ]
     ],


### PR DESCRIPTION
The shim creation does not take RetroArch-Win64 into account.