### PR TITLE
Fix MameUI Download Link

### DIFF
--- a/bucket/mameui.json
+++ b/bucket/mameui.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "http://www.mameui.info/MAMEUI.7z",
+            "url": "http://www.mameui.info/MAMEUI248.7z",
             "hash": "5b7cca7dbcb6c84cb1f06ae613b0f043f3e672c3aa197fd40bc91b56a617885e",
             "extract_dir": "MAMEUI",
             "shortcuts": [


### PR DESCRIPTION
MameUI download link has been changed on the website. Manifest URL updated to match.